### PR TITLE
Add PMUSER_QUEUEIT_EVALUATED variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ and of type **Hidden** in Akamai property manager. The following table describes
 | PMUSER_QUEUEIT_SECRET_KEY | Yes | Find your Secret key in the GO Queue-it Platform. |
 | PMUSER_QUEUEIT_CONFIG_TYPE | Yes | 'inline' or 'cahce' or 'edgekv' |
 | PMUSER_QUEUEIT_API_KEY | If 'PMUSER_QUEUEIT_CONFIG_TYPE' is set to cache  | Find your Api key in the GO Queue-it Platform. |
+| PMUSER_QUEUEIT_EVALUATED | For validation that the Queue-It EdgeWorker was executed | The Queue-It EdgeWorker will set the variable to `true`. This variable can be used in Akamai Property Manager to apply alternative logic if the EdgeWorker was not executed. | 
 
 ### Adding a Site Failover behaviour
 After the EdgeWokrewr behaviour you need to add a Site Failover to do a retry if EW fails.

--- a/main.ts
+++ b/main.ts
@@ -10,6 +10,7 @@ import { logger } from 'log';
 
 const COOKIE_VARIABLE_NAME = 'PMUSER_QUEUEIT_C';
 const ERROR_VARIABLE_NAME = 'PMUSER_QUEUEIT_ER';
+const EVALUATED_VARIABLE_NAME = 'PMUSER_QUEUEIT_EVALUATED';
 const BIG_SET_COOKIE_VALUE = 'TOO_BIG_COOKIE';
 const QUEUEIT_CONNECTOR_EXECUTED_HEADER_NAME = 'x-queueit-connector';
 const QUEUEIT_FAILED_HEADERNAME = 'x-queueit-failed';
@@ -18,6 +19,8 @@ const SHOULD_IGNORE_OPTIONS_REQUESTS = false;
 
 export async function onClientRequest(request) {
     try {
+        // Set PMUSER variable to allow validation that EdgeWorker was executed
+        request.setVariable(EVALUATED_VARIABLE_NAME, 'true');
         if (isIgnored(request)) {
             return;
         }


### PR DESCRIPTION
Add PMUSER_QUEUEIT_EVALUATED variable.  This variable will be set to `true` when the EdgeWorker executes.  The variable can be used in Property Manager match conditions to perform verify execution of the EdgeWorker and apply alternative logic if the EdgeWorker was not executed.